### PR TITLE
docs: add docs index and link from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # ePortfolio
 Projects and Milestones for FS-ADF
+
+## Documentation
+- See [docs/README.md](docs/README.md) for the index.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation Index
+
+- [Feature Branch Workflow](research/feature-branch-workflow.md)


### PR DESCRIPTION
## Summary
Adds docs index and links it from the root README.

## Changes
- docs/README.md
- README.md

## Acceptance
- [ ] Docs index renders with link to Feature Branch Workflow
- [ ] README has "Documentation" section linking to docs index
