### PR TITLE
chore: add issue templates (bug, feature, docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a bug in this repo
+title: "bug: <short title>"
+labels: bug
+---
+**Describe the bug**
+A clear description of the problem.
+
+**Steps to Reproduce**
+1. …
+2. …
+
+**Expected vs Actual**
+- Expected:
+- Actual:
+
+**Screenshots/Logs**
+(attach if helpful)
+
+**Environment**
+OS / tool versions (if relevant)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs_task.md
+++ b/.github/ISSUE_TEMPLATE/docs_task.md
@@ -1,0 +1,15 @@
+---
+name: Docs task
+about: Documentation changes or research notes
+title: "docs: <short title>"
+labels: docs
+---
+**Summary**
+What needs to change/add in docs?
+
+**Files/Sections**
+- …
+
+**Acceptance**
+- [ ] Renders on GitHub
+- [ ] Linked where appropriate

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: "feature: <short title>"
+labels: feature
+---
+**User Story**
+As a <role>, I want <goal> so that <benefit>.
+
+**Acceptance Criteria**
+- [ ] …
+- [ ] …
+
+**Notes/Links**


### PR DESCRIPTION
## Summary
Adds GitHub issue templates for bug reports, feature requests, and docs tasks.

## Acceptance
- [ ] New Issue shows three templates
- [ ] Templates apply labels automatically
