### PR TITLE
chore: add CODEOWNERS placeholder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Replace @INSTRUCTOR with your instructor's GitHub username or team.
+# Example: * @FullSail-Instructors
+* @INSTRUCTOR


### PR DESCRIPTION
## Summary
Adds .github/CODEOWNERS with a placeholder owner. Replace @INSTRUCTOR with the real handle.

## Acceptance
- [ ] CODEOWNERS exists on dev
- [ ] Branch protection on main requires Code Owner review
